### PR TITLE
Explicitly check for `$keyValues` whether they are array or not

### DIFF
--- a/library/Zend/Db/Table/Abstract.php
+++ b/library/Zend/Db/Table/Abstract.php
@@ -1304,7 +1304,9 @@ abstract class Zend_Db_Table_Abstract
         $whereList = array();
         $numberTerms = 0;
         foreach ($args as $keyPosition => $keyValues) {
-            $keyValuesCount = count($keyValues);
+            $keyValuesCount = is_array($keyValues) || $keyValues instanceof Countable
+                ? count($keyValues)
+                : (int)(null !== $keyValues);
             // Coerce the values to an array.
             // Don't simply typecast to array, because the values
             // might be Zend_Db_Expr objects.


### PR DESCRIPTION
Since PHP 7.2 `count()` will emit `E_WARNING` if its first argument isn't an array or `Countable`. 