### PR TITLE
Fix continue in switch statement

### DIFF
--- a/library/Zend/Feed/Entry/Atom.php
+++ b/library/Zend/Feed/Entry/Atom.php
@@ -103,7 +103,7 @@ class Zend_Feed_Entry_Atom extends Zend_Feed_Entry_Abstract
                 // Redirect
                 case 3:
                     $deleteUri = $response->getHeader('Location');
-                    continue;
+                    break;
                 // Error
                 default:
                     /**

--- a/library/Zend/Form.php
+++ b/library/Zend/Form.php
@@ -1170,7 +1170,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
                 } else {
                     switch ($argc) {
                         case 0:
-                            continue;
+                            break;
                         case (1 <= $argc):
                             $type = array_shift($spec);
                         case (2 <= $argc):
@@ -1687,7 +1687,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
                 $order = null;
                 switch ($argc) {
                     case 0:
-                        continue;
+                        break;
                     case (1 <= $argc):
                         $subForm = array_shift($spec);
 

--- a/library/Zend/Reflection/File.php
+++ b/library/Zend/Reflection/File.php
@@ -355,7 +355,7 @@ class Zend_Reflection_File implements Reflector
                 case T_DOLLAR_OPEN_CURLY_BRACES:
                 case T_CURLY_OPEN:
                     $embeddedVariableTrapped = true;
-                    continue;
+                    break;
 
                 // Name of something
                 case T_STRING:
@@ -366,7 +366,7 @@ class Zend_Reflection_File implements Reflector
                         $this->_classes[] = $value;
                         $classTrapped = false;
                     }
-                    continue;
+                    break;
 
                 // Required file names are T_CONSTANT_ENCAPSED_STRING
                 case T_CONSTANT_ENCAPSED_STRING:
@@ -374,7 +374,7 @@ class Zend_Reflection_File implements Reflector
                         $this->_requiredFiles[] = $value ."\n";
                         $requireTrapped = false;
                     }
-                    continue;
+                    break;
 
                 // Functions
                 case T_FUNCTION:


### PR DESCRIPTION
In PHP, if continue is applied to a switch statement, it behaves the same as break.
PHP 7.3 throws warning ""continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?", PHP 8 will generates a compile error.