### PR TITLE
Update "require.php" version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.2.11"
+        "php": ">=8.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
There is [code in plesk/zf1@1.12.17-patch10](https://github.com/plesk/zf1/blob/1.12.17-patch10/library/Zend/Form.php#L3275) that requires PHP 8.0 [Union types](https://php.watch/versions/8.0/union-types).

This change sets required PHP version to `>=8.0`.